### PR TITLE
[EuiToolTip] Memoized tool_tip_arrow component

### DIFF
--- a/packages/eui/src/components/tool_tip/tool_tip_arrow.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip_arrow.tsx
@@ -7,15 +7,14 @@
  */
 
 import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { ToolTipPositions } from './tool_tip_popover';
 import { euiToolTipStyles } from './tool_tip.styles';
 
 export const EuiToolTipArrow: FunctionComponent<
   { position: ToolTipPositions } & HTMLAttributes<HTMLDivElement>
 > = ({ position, ...props }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiToolTipStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiToolTipStyles);
   const cssStyles = [styles.euiToolTip__arrow, styles.arrowPositions[position]];
 
   return <div css={cssStyles} {...props} />;


### PR DESCRIPTION
This pull request introduces memoization for the EuiToolTipArrow component to improve performance and reduce unnecessary renders.

## Changes Made:

Use of useEuiMemoizedStyles:

Replaced useEuiTheme with useEuiMemoizedStyles to memoize the component's styles.

This ensures that styles are only recalculated when necessary, optimizing performance.